### PR TITLE
Fixes bug with issue templates (#7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,12 @@
-______________________________________________________________________
+---
 
 name: Bug report
 about: Create a report to help us improve
-title: 'BUG: \[3-5 word summary\]'
+title: 'BUG:'
 labels: bug
 assignees: ''
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -25,7 +25,7 @@ Steps to reproduce the behavior:
 
 A clear and concise description of what you expected to happen.
 
-### Screenshots\*\*
+### Screenshots
 
 If applicable, add screenshots to help explain your problem.
 
@@ -33,12 +33,12 @@ If applicable, add screenshots to help explain your problem.
 
 ### Computer
 
-- **Operating System:** \[Windows | Mac | Linux\]
-- **Version** \[e.g. macOS Big Sur 11.2.3\]
+- **Operating System:** {Windows | Mac | Linux}
+- **Version** {e.g. macOS Big Sur 11.2.3}
 
 ### Python Environment
 
-- **Python Version:** \[e.g. 3.7.7\]
+- **Python Version:** {e.g. 3.7.7}
 - **Package Versions:** Paste the output of `pip list` below
 
 ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 
 name: Feature request
 about: Suggest an idea for this project
-title: 'FEATURE: \[3-5 word summary\]'
+title: 'FEATURE:'
 labels: enhancement
 assignees: ''
 
@@ -14,21 +14,21 @@ A clear and concise description of what you want to happen.
 
 ### Is your feature request related to a problem?
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when \[...\]
+A clear and concise description of what the problem is. Ex. I'm always frustrated when {...}
 
 ### Desired Behavior
 
 A more detailed breakdown of the behavior you expect from this new feature.
 
-- \[Description of behavior 1\]
-- \[Description of behavior 2\]
+- {Description of behavior 1}
+- {Description of behavior 2}
 
 ## Alternatives Considered
 
 Briefly describe other features or solutions that were considered before making this request
 
-- **\[Alternative 1\]:** \[Description of why it wasn't viable\]
-- **\[Alternative 2\]:** \[Description of why it wasn't viable\]
+- **{Alternative 1}:** {Description of why it wasn't viable}
+- **{Alternative 2}:** {Description of why it wasn't viable}
 
 ### Additional Context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-______________________________________________________________________
+---
 
 name: Feature request
 about: Suggest an idea for this project
@@ -6,7 +6,7 @@ title: 'FEATURE: \[3-5 word summary\]'
 labels: enhancement
 assignees: ''
 
-______________________________________________________________________
+---
 
 ## Feature Overview
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,4 +1,4 @@
-______________________________________________________________________
+---
 
 name: Task
 about: Outline changes that need to be made to the codebase
@@ -6,7 +6,7 @@ title: Task
 labels: enhancement
 assignees: ''
 
-______________________________________________________________________
+---
 
 ## Summary
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 
 name: Task
 about: Outline changes that need to be made to the codebase
-title: Task
+title: 'TASK:'
 labels: enhancement
 assignees: ''
 
@@ -14,10 +14,10 @@ Clear and concise summary of the work that needs to be completed
 
 ## To Do
 
-- \[ \] \[Description of change 1\]
-- \[ \] \[Description of change 2\]
+- [ ] {Description of change 1}
+- [ ] {Description of change 2}
 
 ## Definition of Done
 
-- \[ \] \[Description of expected behavior once changes are made\]
-- \[ \] \[Description of expected behavior once changes are made\]
+- [ ] {Description of expected behavior once changes are made}
+- [ ] {Description of expected behavior once changes are made}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,13 +6,13 @@ Fixes #
 
 ## Changes Proposed
 
-- \[Description of change 1\]
-- \[Description of change 2\]
+- {Description of change 1}
+- {Description of change 2}
 
 ## Blockers or Questions
 
-- \[ \] \[Concise description of blocker or question 1 that may prevent merge\]
-- \[ \] \[Concise description of blocker or question 2 that may prevent merge\]
+- [ ] {Concise description of blocker or question 1 that may prevent merge}
+- [ ] {Concise description of blocker or question 2 that may prevent merge}
 
 ## Additional Context
 
@@ -21,5 +21,5 @@ Brief description of context
 ## Instructions to Review
 
 1. [Checkout PR Locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally)
-1. \[Step 2\]
-1. \[Step 3\]
+1. {Step 2}
+1. {Step 3}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Concise description of changes proposed in this pull request
 
-**Fixes** #
+Fixes #
 
 ## Changes Proposed
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac files
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,3 @@ repos:
   rev: 3.9.2  # change this to the most recent stable release
   hooks:
   - id: flake8
-- repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.6  # Use the ref you want to point at
-  hooks:
-  - id: mdformat
-    # Optionally add plugins
-    additional_dependencies:
-    - mdformat-gfm
-    - mdformat-black

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps = -rrequirements.txt
 commands = black src tests
            pylint src tests
            flake8 src tests
-           mdformat .
 
 [testenv:checkdeps]
 deps = -rrequirements.txt


### PR DESCRIPTION
## Summary

Fixes the bug with issue templates not working by removing auto-formatting of markdown files using `mdformat`

Fixes #7 

## Changes Proposed

- Removes `mdformat` from `pre-commit-config.yml` and `tox.ini`
- Reverts formatting changes in all of the markdown files in `.github/`

## Blockers or Questions

- [ ] We may want to re-implement `mdformat` if we can apply it to a specific directory

## Instructions to Review

Unfortunately the issue creation functionality can't be reviewed before merging